### PR TITLE
🩹 fix nil request body bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ go get -u github.com/gofiber/adaptor
 | HTTPHandlerFunc | `HTTPHandlerFunc(h http.HandlerFunc) func(*fiber.Ctx)` | http.HandlerFunc -> Fiber handler
 | FiberHandler | `FiberHandler(h func(*fiber.Ctx)) http.Handler` | Fiber handler -> http.Handler
 | FiberHandlerFunc | `FiberHandlerFunc(h func(*fiber.Ctx)) http.HandlerFunc` | Fiber handler -> http.HandlerFunc
+| FiberApp | `FiberApp(app *fiber.App) http.HandlerFunc` | Fiber app -> http.HandlerFunc
 
 ### net/http to Fiber
 ```go
@@ -57,7 +58,7 @@ func greet(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-### Fiber to net/http
+### Fiber Handler to net/http
 ```go
 package main
 
@@ -77,6 +78,29 @@ func main() {
 
 	// Listen on port 3000
 	http.ListenAndServe(":3000", nil)
+}
+
+func greet(c *fiber.Ctx) {
+	c.Send("Hello World!")
+}
+```
+
+### Fiber App to net/http
+```go
+package main
+
+import (
+	"github.com/gofiber/adaptor"
+	"github.com/gofiber/fiber"
+	"net/http"
+)
+func main() {
+	app := fiber.New()
+
+	app.Get("/greet", greet)
+
+	// Listen on port 3000
+	http.ListenAndServe(":3000", adaptor.FiberApp(app))
 }
 
 func greet(c *fiber.Ctx) {

--- a/main.go
+++ b/main.go
@@ -80,3 +80,48 @@ func FiberHandlerFunc(h func(*fiber.Ctx)) http.HandlerFunc {
 		_, _ = w.Write(ctx.Fasthttp.Response.Body())
 	}
 }
+
+// FiberApp wraps fiber app to net/http handler func
+func FiberApp(app *fiber.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// New fasthttp request
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		// Convert net/http -> fasthttp request
+		if r.Body != nil {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
+				return
+			}
+			req.Header.SetContentLength(len(body))
+			_, _ = req.BodyWriter().Write(body)
+		}
+		req.Header.SetMethod(r.Method)
+		req.SetRequestURI(r.RequestURI)
+		req.SetHost(r.Host)
+		for key, val := range r.Header {
+			for _, v := range val {
+				req.Header.Add(key, v)
+			}
+		}
+		remoteAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
+		if err != nil {
+			http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
+			return
+		}
+
+		// New fasthttp Ctx
+		var fctx fasthttp.RequestCtx
+		fctx.Init(req, remoteAddr, nil)
+		// Execute fasthttp Ctx
+		app.Handler()(&fctx)
+
+		// Convert fasthttp Ctx > net/http
+		fctx.Response.Header.VisitAll(func(k, v []byte) {
+			w.Header().Set(string(k), string(v))
+		})
+		w.WriteHeader(fctx.Response.StatusCode())
+		_, _ = w.Write(fctx.Response.Body())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -34,55 +34,16 @@ func FiberHandler(h func(*fiber.Ctx)) http.Handler {
 }
 
 // FiberHandlerFunc wraps fiber handler to net/http handler func
-func FiberHandlerFunc(h func(*fiber.Ctx)) http.HandlerFunc {
-	app := fiber.New()
-	return func(w http.ResponseWriter, r *http.Request) {
-		// New fasthttp request
-		req := fasthttp.AcquireRequest()
-		defer fasthttp.ReleaseRequest(req)
-		// Convert net/http -> fasthttp request
-		if r.Body != nil {
-			body, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
-				return
-			}
-			req.Header.SetContentLength(len(body))
-			_, _ = req.BodyWriter().Write(body)
-		}
-		req.Header.SetMethod(r.Method)
-		req.SetRequestURI(r.RequestURI)
-		req.SetHost(r.Host)
-		for key, val := range r.Header {
-			for _, v := range val {
-				req.Header.Add(key, v)
-			}
-		}
-		remoteAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
-		if err != nil {
-			http.Error(w, utils.StatusMessage(fiber.StatusInternalServerError), fiber.StatusInternalServerError)
-			return
-		}
-
-		// New fasthttp Ctx
-		var fctx fasthttp.RequestCtx
-		fctx.Init(req, remoteAddr, nil)
-		// New fiber Ctx
-		ctx := app.AcquireCtx(&fctx)
-		defer app.ReleaseCtx(ctx)
-		// Execute fiber Ctx
-		h(ctx)
-		// Convert fasthttp Ctx > net/http
-		ctx.Fasthttp.Response.Header.VisitAll(func(k, v []byte) {
-			w.Header().Set(string(k), string(v))
-		})
-		w.WriteHeader(ctx.Fasthttp.Response.StatusCode())
-		_, _ = w.Write(ctx.Fasthttp.Response.Body())
-	}
+func FiberHandlerFunc(h fiber.Handler) http.HandlerFunc {
+	return handlerFunc(fiber.New(), h)
 }
 
 // FiberApp wraps fiber app to net/http handler func
 func FiberApp(app *fiber.App) http.HandlerFunc {
+	return handlerFunc(app)
+}
+
+func handlerFunc(app *fiber.App, h ...fiber.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// New fasthttp request
 		req := fasthttp.AcquireRequest()
@@ -114,8 +75,16 @@ func FiberApp(app *fiber.App) http.HandlerFunc {
 		// New fasthttp Ctx
 		var fctx fasthttp.RequestCtx
 		fctx.Init(req, remoteAddr, nil)
-		// Execute fasthttp Ctx
-		app.Handler()(&fctx)
+		if len(h) > 0 {
+			// New fiber Ctx
+			ctx := app.AcquireCtx(&fctx)
+			defer app.ReleaseCtx(ctx)
+			// Execute fiber Ctx
+			h[0](ctx)
+		} else {
+			// Execute fasthttp Ctx though app.Handler
+			app.Handler()(&fctx)
+		}
 
 		// Convert fasthttp Ctx > net/http
 		fctx.Response.Header.VisitAll(func(k, v []byte) {

--- a/main_test.go
+++ b/main_test.go
@@ -98,7 +98,7 @@ func Test_HTTPHandler(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "request body is %q", body)
 	}
-	fiberH := HTTPHandler(http.HandlerFunc(nethttpH))
+	fiberH := HTTPHandlerFunc(http.HandlerFunc(nethttpH))
 	fiberH = setFiberContextValueMiddleware(fiberH, expectedContextKey, expectedContextValue)
 
 	var fctx fasthttp.RequestCtx
@@ -145,6 +145,14 @@ func Test_HTTPHandler(t *testing.T) {
 }
 
 func Test_FiberHandler(t *testing.T) {
+	testFiberToHandlerFunc(t)
+}
+
+func Test_FiberApp(t *testing.T) {
+	testFiberToHandlerFunc(t, fiber.New())
+}
+
+func testFiberToHandlerFunc(t *testing.T, app ...*fiber.App) {
 	expectedMethod := fiber.MethodPost
 	expectedRequestURI := "/foo/bar?baz=123"
 	expectedBody := "body 123 foo bar baz"
@@ -201,7 +209,14 @@ func Test_FiberHandler(t *testing.T) {
 		c.Status(fiber.StatusBadRequest)
 		c.Write(fmt.Sprintf("request body is %q", body))
 	}
-	nethttpH := FiberHandler(fiberH)
+
+	var handlerFunc http.HandlerFunc
+	if len(app) > 0 {
+		app[0].Post("/foo/bar", fiberH)
+		handlerFunc = FiberApp(app[0])
+	} else {
+		handlerFunc = FiberHandlerFunc(fiberH)
+	}
 
 	var r http.Request
 
@@ -219,7 +234,7 @@ func Test_FiberHandler(t *testing.T) {
 	r.Header = hdr
 
 	var w netHTTPResponseWriter
-	nethttpH.ServeHTTP(&w, &r)
+	handlerFunc.ServeHTTP(&w, &r)
 
 	if w.StatusCode() != http.StatusBadRequest {
 		t.Fatalf("unexpected statusCode: %d. Expecting %d", w.StatusCode(), http.StatusBadRequest)
@@ -233,6 +248,13 @@ func Test_FiberHandler(t *testing.T) {
 	expectedResponseBody := fmt.Sprintf("request body is %q", expectedBody)
 	if string(w.body) != expectedResponseBody {
 		t.Fatalf("unexpected response body %q. Expecting %q", string(w.body), expectedResponseBody)
+	}
+}
+
+func setFiberContextValueMiddleware(next func(*fiber.Ctx), key string, value interface{}) func(*fiber.Ctx) {
+	return func(c *fiber.Ctx) {
+		c.Locals(key, value)
+		next(c)
 	}
 }
 
@@ -270,108 +292,6 @@ func Test_FiberHandler_RequestNilBody(t *testing.T) {
 	expectedResponseBody := "request body is nil"
 	if string(w.body) != expectedResponseBody {
 		t.Fatalf("unexpected response body %q. Expecting %q", string(w.body), expectedResponseBody)
-	}
-}
-
-func Test_FiberApp(t *testing.T) {
-	expectedMethod := fiber.MethodPost
-	expectedRequestURI := "/foo/bar?baz=123"
-	expectedBody := "body 123 foo bar baz"
-	expectedContentLength := len(expectedBody)
-	expectedHost := "foobar.com"
-	expectedRemoteAddr := "1.2.3.4:6789"
-	expectedHeader := map[string]string{
-		"Foo-Bar":         "baz",
-		"Abc":             "defg",
-		"XXX-Remote-Addr": "123.43.4543.345",
-	}
-	expectedURL, err := url.ParseRequestURI(expectedRequestURI)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	callsCount := 0
-	fiberH := func(c *fiber.Ctx) {
-		callsCount++
-		if c.Method() != expectedMethod {
-			t.Fatalf("unexpected method %q. Expecting %q", c.Method(), expectedMethod)
-		}
-		if string(c.Fasthttp.RequestURI()) != expectedRequestURI {
-			t.Fatalf("unexpected requestURI %q. Expecting %q", string(c.Fasthttp.RequestURI()), expectedRequestURI)
-		}
-		contentLength := c.Fasthttp.Request.Header.ContentLength()
-		if contentLength != expectedContentLength {
-			t.Fatalf("unexpected contentLength %d. Expecting %d", contentLength, expectedContentLength)
-		}
-		if c.Hostname() != expectedHost {
-			t.Fatalf("unexpected host %q. Expecting %q", c.Hostname(), expectedHost)
-		}
-		remoteAddr := c.Fasthttp.RemoteAddr().String()
-		if remoteAddr != expectedRemoteAddr {
-			t.Fatalf("unexpected remoteAddr %q. Expecting %q", remoteAddr, expectedRemoteAddr)
-		}
-		body := c.Body()
-		if body != expectedBody {
-			t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
-		}
-		if c.OriginalURL() != expectedURL.String() {
-			t.Fatalf("unexpected URL: %#v. Expecting %#v", c.OriginalURL(), expectedURL)
-		}
-
-		for k, expectedV := range expectedHeader {
-			v := c.Get(k)
-			if v != expectedV {
-				t.Fatalf("unexpected header value %q for key %q. Expecting %q", v, k, expectedV)
-			}
-		}
-
-		c.Set("Header1", "value1")
-		c.Set("Header2", "value2")
-		c.Status(fiber.StatusBadRequest)
-		c.Write(fmt.Sprintf("request body is %q", body))
-	}
-
-	app := fiber.New()
-	app.Post("/foo/bar", fiberH)
-	nethttpH := FiberApp(app)
-
-	var r http.Request
-
-	r.Method = expectedMethod
-	r.Body = &netHTTPBody{[]byte(expectedBody)}
-	r.RequestURI = expectedRequestURI
-	r.ContentLength = int64(expectedContentLength)
-	r.Host = expectedHost
-	r.RemoteAddr = expectedRemoteAddr
-
-	hdr := make(http.Header)
-	for k, v := range expectedHeader {
-		hdr.Set(k, v)
-	}
-	r.Header = hdr
-
-	var w netHTTPResponseWriter
-	nethttpH.ServeHTTP(&w, &r)
-
-	if w.StatusCode() != http.StatusBadRequest {
-		t.Fatalf("unexpected statusCode: %d. Expecting %d", w.StatusCode(), http.StatusBadRequest)
-	}
-	if w.Header().Get("Header1") != "value1" {
-		t.Fatalf("unexpected header value: %q. Expecting %q", w.Header().Get("Header1"), "value1")
-	}
-	if w.Header().Get("Header2") != "value2" {
-		t.Fatalf("unexpected header value: %q. Expecting %q", w.Header().Get("Header2"), "value2")
-	}
-	expectedResponseBody := fmt.Sprintf("request body is %q", expectedBody)
-	if string(w.body) != expectedResponseBody {
-		t.Fatalf("unexpected response body %q. Expecting %q", string(w.body), expectedResponseBody)
-	}
-}
-
-func setFiberContextValueMiddleware(next func(*fiber.Ctx), key string, value interface{}) func(*fiber.Ctx) {
-	return func(c *fiber.Ctx) {
-		c.Locals(key, value)
-		next(c)
 	}
 }
 


### PR DESCRIPTION
If request body is nil, adaptor will panic at `ioutil.ReadAll(r.Body)`